### PR TITLE
Generic commands

### DIFF
--- a/commands/help.js
+++ b/commands/help.js
@@ -1,0 +1,4 @@
+module.exports = () => {
+  console.warn('Help is not supported yet');
+};
+

--- a/commands/version.js
+++ b/commands/version.js
@@ -1,0 +1,6 @@
+const { version } = require('../package.json');
+
+module.exports = () => {
+  console.log(`v${version}`);
+};
+

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const add = require('./commands/add');
 const list = require('./commands/list');
 const remove = require('./commands/remove');
 const version = require('./commands/version');
+const help = require('./commands/help');
 
 module.exports = () => {
   const args = minimist(process.argv.slice(2));
@@ -12,6 +13,10 @@ module.exports = () => {
   // Usage: note -v or note --version
   if (args.v || args.version) {
     cmd = 'version';
+  }
+  // Usage: note -h or note --help
+  if (args.h || args.help) {
+    cmd = 'help';
   }
 
   switch (cmd) {
@@ -26,6 +31,9 @@ module.exports = () => {
       break;
     case 'version':
       version();
+      break;
+    case 'help':
+      help();
       break;
     default:
       console.error(`"${cmd}" is not a valid command`);

--- a/index.js
+++ b/index.js
@@ -2,10 +2,18 @@ const minimist = require('minimist');
 const add = require('./commands/add');
 const list = require('./commands/list');
 const remove = require('./commands/remove');
+const version = require('./commands/version');
 
 module.exports = () => {
   const args = minimist(process.argv.slice(2));
-  const cmd = args._[0];
+  let cmd = args._[0];
+
+  // Added to support the more traditional method of passing flags
+  // Usage: note -v or note --version
+  if (args.v || args.version) {
+    cmd = 'version';
+  }
+
   switch (cmd) {
     case 'add':
       add(args);
@@ -15,6 +23,9 @@ module.exports = () => {
       break;
     case 'remove':
       remove(args);
+      break;
+    case 'version':
+      version();
       break;
     default:
       console.error(`"${cmd}" is not a valid command`);

--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ const help = require('./commands/help');
 
 module.exports = () => {
   const args = minimist(process.argv.slice(2));
-  let cmd = args._[0];
+  // When args._[0] is undefined, cmd will be help
+  let cmd = args._[0] || 'help';
 
   // Added to support the more traditional method of passing flags
   // Usage: note -v or note --version


### PR DESCRIPTION
This pull request adds support for the very common `help` and `version` commands.
In addition to having the ability to be invoked as a traditional command, the `help` and `version` commands can also be triggered using flags (`-v`, `-h`, `--version` and `--help`), as seem in many other CLI apps.

Additionally, the help command is invoked whenever no commands are passed at all.

The `help` command's content, however, is currently unsupported as all the app's possible commands have not been decided.
