### PR TITLE
Adds functionality of Listing notes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,7 @@
             "single"
         ],
         "no-console": "off",
+        "brace-style": "error",
         "semi": [
             "error",
             "always"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,7 @@
         ],
         "no-console": "off",
         "brace-style": "error",
+        "eqeqeq": "error",
         "semi": [
             "error",
             "always"

--- a/commands/default.js
+++ b/commands/default.js
@@ -9,7 +9,7 @@ const dir = `${require('os').homedir()}/.terminote/`;
 module.exports = (args) => {
   let filename = args.f || args.file;
   if (!filename) {
-    error('Error! Please put a -f flag in front of your filename', true);
+    error('Error! Please put a -f followed by a <filename> to use the note default command', true);
   }
   filename = jsonCheck(filename);
   if (!fileExists(filename)) {

--- a/commands/list.js
+++ b/commands/list.js
@@ -19,6 +19,9 @@ module.exports = (args) => {
     } else {
       checkbox = '❌';
     }
+    if (!entries[i].content) {
+      continue;
+    }
     console.log(checkbox + '   ' + entries[i].content[colour]);
   }
 };

--- a/commands/list.js
+++ b/commands/list.js
@@ -7,14 +7,14 @@ module.exports = (args) => {
   const { title, titleColour, colour, type, entries } = file;
   let checkbox;
   console.log(title[titleColour] + '\n');
+
   if (entries.length === 0) {
     error('There are no entries in this list', true, 0);
   }
   for (let i = 0; i < entries.length; i++) {
-    if (type == 'Dot-jots') {
+    if (type === 'Dot-jots') {
       checkbox = ' ●';
-    }
-    else if (entries[i].checked === true) {
+    } else if (entries[i].checked === true) {
       checkbox = '✅';
     } else {
       checkbox = '❌';

--- a/commands/list.js
+++ b/commands/list.js
@@ -6,7 +6,7 @@ module.exports = (args) => {
   let checkbox;
   console.log(title[titleColour] + '\n');
 
-  if (!entries.length) {
+  if (entries.length === 0) {
     error('There are no entries in this list', true, 0);
   }
   for (let i = 0; i < entries.length; i++) {

--- a/commands/list.js
+++ b/commands/list.js
@@ -1,4 +1,25 @@
+const dir = `${require('os').homedir()}/.terminote/`;
+const color = require('colors');
+const error = require('../util/error');
+
 module.exports = (args) => {
-  console.log('Here are your notes!');
+  const file = require(dir + args.f);
+  const { title, titleColour, colour, type, entries } = file;
+  let checkbox;
+  console.log(title[titleColour] + '\n');
+  if (entries.length === 0) {
+    error('There are no entries in this list', true, 0);
+  }
+  for (let i = 0; i < entries.length; i++) {
+    if (type == 'Dot-jots') {
+      checkbox = ' ●';
+    }
+    else if (entries[i].checked === true) {
+      checkbox = '✅';
+    } else {
+      checkbox = '❌';
+    }
+    console.log(checkbox + '   ' + entries[i].content[colour]);
+  }
 };
 

--- a/commands/list.js
+++ b/commands/list.js
@@ -1,20 +1,18 @@
-const dir = `${require('os').homedir()}/.terminote/`;
 const color = require('colors');
 const error = require('../util/error');
 
 module.exports = (args) => {
-  const file = require(dir + args.f);
-  const { title, titleColour, colour, type, entries } = file;
+  const { title, titleColour, colour, type, entries } = require(`${require('os').homedir()}/.terminote/` + args.f);
   let checkbox;
   console.log(title[titleColour] + '\n');
 
-  if (entries.length === 0) {
+  if (!entries.length) {
     error('There are no entries in this list', true, 0);
   }
   for (let i = 0; i < entries.length; i++) {
     if (type === 'Dot-jots') {
       checkbox = ' ●';
-    } else if (entries[i].checked === true) {
+    } else if (entries[i].checked) {
       checkbox = '✅';
     } else {
       checkbox = '❌';

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ module.exports = async () => {
       break;
   }
 
-  if ((args.l || args.list) && args._[0] != 'list') {
+  if ((args.l || args.list) && args._[0] !== 'list') {
     list(args);
   }
 };

--- a/index.js
+++ b/index.js
@@ -65,5 +65,9 @@ module.exports = async () => {
       console.error(`"${cmd}" is not a valid command`);
       break;
   }
+
+  if ((args.l || args.list) && args._[0] != 'list') {
+    list(args);
+  }
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "TermiNote",
+  "name": "notetaker",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -62,6 +62,11 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "colors": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/JessicaLim8/NoteTaker#readme",
   "dependencies": {
+    "colors": "^1.3.3",
     "inquirer": "^6.2.2",
     "minimist": "^1.2.0"
   }

--- a/util/makeFile.js
+++ b/util/makeFile.js
@@ -13,6 +13,17 @@ module.exports = (args) => {
       choices: ['Checkboxes', 'Dot-jots'],
     },
     {
+      type: 'input',
+      message: 'What would you like to title your file? (Note: this is the displayed title, not your file name)',
+      name: 'title',
+    },
+    {
+      type: 'list',
+      message: 'What colour would you like the title to be?',
+      name: 'titleColour',
+      choices: ['white', 'black', 'cyan', 'green', 'blue'],
+    },
+    {
       type: 'list',
       message: 'What is the default colour of this list?',
       name: 'colour',
@@ -21,7 +32,7 @@ module.exports = (args) => {
     if (!args.f && !args.file) {
       questions.unshift({
         type: 'input',
-        message: 'What would you like to call your new file?',
+        message: 'What would you like the name of your file to be?',
         name: 'name',
       });
     } else {

--- a/util/makeFile.js
+++ b/util/makeFile.js
@@ -21,13 +21,13 @@ module.exports = (args) => {
       type: 'list',
       message: 'What colour would you like the title to be?',
       name: 'titleColour',
-      choices: ['white', 'black', 'cyan', 'green', 'blue'],
+      choices: ['white', 'black', 'red', 'magenta', 'yellow', 'green', 'blue'],
     },
     {
       type: 'list',
       message: 'What is the default colour of this list?',
       name: 'colour',
-      choices: ['white', 'black', 'cyan', 'green', 'blue'],
+      choices: ['white', 'black', 'red', 'magenta', 'yellow', 'green', 'blue'],
     }];
     if (!args.f && !args.file) {
       questions.unshift({


### PR DESCRIPTION
## Adds ability to list notes

### New functions
Allows for lists to be displayed on console via `note list <filename>` or using the `-l` or `--list` flag with existing commands. Closes issue #15 

#### Note List command

- Will list all the elements within the called filename
- If the list doesn't exist, it will be made
- If no list is included, the default list will be displayed

#### Note List features
- Will display the title, coloured by property
- Will display each element in the appropriate colour
- Elements are displayed with either checkmarks/crosses if they are of checkbox type, or points, if they are dot-jot notes (according to the filename's properties
- If the element is empty, it will not be displayed

#### Listing flags

- If `-l` or `--list` is flagged in any command, after the command is completed, the altered list is displayed
- Default of `-l` is false (will not list elements unless flag is present)
- If flag is pulled with conjunction with `note list` i. e. `note list -f <listname> -l`, it will only list once