### PR TITLE
Delete files

### DIFF
--- a/commands/deleteFile.js
+++ b/commands/deleteFile.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const dir = `${require('os').homedir()}/.terminote/`;
+const inquirer = require('inquirer');
+const error = require('../util/error');
+
+module.exports = async () => {
+  let files = fs.readdirSync(dir).filter((file) => {
+    return file !== 'default.json';
+  });
+  let { file } = await inquirer.prompt([{
+    type: 'list',
+    name: 'file',
+    message: 'Please select the file you would like to delete',
+    choices: files,
+  }]);
+  let { confirm } = await inquirer.prompt([{
+    type: 'confirm',
+    name: 'confirm',
+    message: `Are you sure you want to delete ${file}? All entries will be deleted and they cannot be recovered`,
+    default: false,
+  }]);
+  if (!confirm) {
+    error('Your file was not deleted', true, 0);
+  } else {
+    fs.unlink(dir + file, err => {
+      if (err) {
+        return err;
+      }
+      console.log(`Your file ${file} has been deleted`);
+    });
+  }
+};
+

--- a/commands/deleteFile.js
+++ b/commands/deleteFile.js
@@ -2,17 +2,30 @@ const fs = require('fs');
 const dir = `${require('os').homedir()}/.terminote/`;
 const inquirer = require('inquirer');
 const error = require('../util/error');
+const jsonCheck = require('../util/jsonCheck');
+const fileExists = require('../util/fileExists');
 
-module.exports = async () => {
-  let files = fs.readdirSync(dir).filter((file) => {
-    return file !== 'default.json';
-  });
-  let { file } = await inquirer.prompt([{
-    type: 'list',
-    name: 'file',
-    message: 'Please select the file you would like to delete',
-    choices: files,
-  }]);
+module.exports = async (args) => {
+  let file = args.f || args.file;
+  //if no filename was given
+  if (!file) {
+    let files = fs.readdirSync(dir).filter((file) => {
+      return file !== 'default.json';
+    });
+    let { selection } = await inquirer.prompt([{
+      type: 'list',
+      name: 'selection',
+      message: 'Please select the file you would like to delete',
+      choices: files,
+    }]);
+    file = selection;
+  //checks to see if the file is valid
+  if (!fileExists(file)) {
+    error('Your file does not exist', true);
+  }
+  file = jsonCheck(file);
+  }
+  // confirms user wants to delete file
   let { confirm } = await inquirer.prompt([{
     type: 'confirm',
     name: 'confirm',
@@ -26,7 +39,7 @@ module.exports = async () => {
       if (err) {
         return err;
       }
-      console.log(`Your file ${file} has been deleted`);
+      console.log(`Your file "${file}" has been deleted`);
     });
   }
 };

--- a/commands/deleteFile.js
+++ b/commands/deleteFile.js
@@ -19,12 +19,12 @@ module.exports = async (args) => {
       choices: files,
     }]);
     file = selection;
+  }
   //checks to see if the file is valid
   if (!fileExists(file)) {
     error('Your file does not exist', true);
   }
   file = jsonCheck(file);
-  }
   // confirms user wants to delete file
   let { confirm } = await inquirer.prompt([{
     type: 'confirm',

--- a/commands/list.js
+++ b/commands/list.js
@@ -4,7 +4,7 @@ const error = require('../util/error');
 module.exports = (args) => {
   const { title, titleColour, colour, type, entries } = require(`${require('os').homedir()}/.terminote/` + args.f);
   let checkbox;
-  console.log(title[titleColour] + '\n');
+  console.log(title[titleColour]);
 
   if (entries.length === 0) {
     error('There are no entries in this list', true, 0);

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = async () => {
   if (args.h || args.help) {
     cmd = 'help';
   }
-  if (cmd !== 'default') {
+  if (cmd !== 'default' && cmd !== 'deletefile' && cmd !== 'help' && cmd !== 'version') {
     if (filename) {
       filename = jsonCheck(filename);
       if (!fileExists(filename)) {

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const minimist = require('minimist');
 const add = require('./commands/add');
 const list = require('./commands/list');
 const remove = require('./commands/remove');
+const deleteFile = require('./commands/deleteFile');
 const jsonCheck = require('./util/jsonCheck');
 const version = require('./commands/version');
 const help = require('./commands/help');
@@ -59,6 +60,9 @@ module.exports = async () => {
       break;
     case 'help':
       help();
+      break;
+    case 'deletefile':
+      deleteFile(args);
       break;
     case 'default':
       setDefault(args);


### PR DESCRIPTION
### Allows users to delete entire files
Added command `note deletefile` will delete an entire file, to fix issue #23 

#### How this is done
- By importing fs, the path of the required file is provided so it can be deleted
- Users may provide the file via a flag in commandline `note deletefile -f <filename>`
- Users may also provide the file via a dropdown menu using Inquirer `note deletefile`

#### Command stipulations
- If no flag is given, a list of options will require
- If a `-f <filename>` flag is given, the following filename will be deleted
- If a `-f <filename>` flag is given, but the filename does not exist, an error will be thrown